### PR TITLE
Remove incorrect documentation

### DIFF
--- a/mesh_tensorflow/ops.py
+++ b/mesh_tensorflow/ops.py
@@ -6108,9 +6108,7 @@ def while_loop(cond_fn, body_fn, inputs, num_loop_vars=None,
   num_loop_vars=k, then all of the loop variables except for the first k
   are handled as mtf Variables instead of loop variables, using explicit
   updates and control dependencies.  In this case, we only return the
-  first num_loop_vars outputs.  Do not use this option on TPU, since it
-  is unnecessary and also produces incorrect results, since xla does not
-  respect control dependencies.
+  first num_loop_vars outputs.
 
   Args:
     cond_fn: a function from n Tensors to scalar boolean Tensor


### PR DESCRIPTION
The documentation of `mtf.while_loop` implies that control_dependencies doesn't work on TPUs. This was true early in the lifecycle of TPU development, but TPUs respect control_dependencies now. I emailed TFRC to ask about this. It was a similar situation: someone on our team found documentation in a tensorflow codebase somewhere that implied TPUs don't respect control_dependencies. So now I'm going around attempting to remove such inaccuracies, as it's no longer relevant.

It's possible that this documentation might be correct *if* it's referring to some special XLA op rather than `tf.control_dependencies`, but it sounds like it's talking about `tf.control_dependencies`.